### PR TITLE
Changed font name in Metadata

### DIFF
--- a/OpenBaskerville.ufo/fontinfo.plist
+++ b/OpenBaskerville.ufo/fontinfo.plist
@@ -11,21 +11,21 @@
 	<key>descender</key>
 	<integer>-204</integer>
 	<key>familyName</key>
-	<string>Large Frys</string>
+	<string>Open Baskerville</string>
 	<key>fondID</key>
 	<integer>128</integer>
 	<key>fondName</key>
-	<string>Large Frys</string>
+	<string>Open Baskerville</string>
 	<key>fontName</key>
-	<string>LargeFrys</string>
+	<string>OpenBaskerville</string>
 	<key>fontStyle</key>
 	<integer>64</integer>
 	<key>fullName</key>
-	<string>Large Frys</string>
+	<string>Open Baskerville</string>
 	<key>italicAngle</key>
 	<real>0.0</real>
 	<key>menuName</key>
-	<string>Large Frys</string>
+	<string>Open Baskerville</string>
 	<key>msCharSet</key>
 	<integer>0</integer>
 	<key>slantAngle</key>


### PR DESCRIPTION
Hi Simon,

Otherwise the generated font shows up as ‘Large Frys’ in your font menu.
