### PR TITLE
Reviewed and reversed few glyphs' contour directions

### DIFF
--- a/OpenBaskerville.ufo/glyphs/C_.glif
+++ b/OpenBaskerville.ufo/glyphs/C_.glif
@@ -4,39 +4,39 @@
   <unicode hex="0043"/>
   <outline>
     <contour>
-      <point x="630" y="465" type="line"/>
-      <point x="588" y="632"/>
-      <point x="508" y="678"/>
-      <point x="396" y="678" type="curve" smooth="yes"/>
-      <point x="262" y="678"/>
-      <point x="159" y="525"/>
-      <point x="159" y="338" type="curve" smooth="yes"/>
-      <point x="159" y="152"/>
-      <point x="261" y="12"/>
-      <point x="412" y="12" type="curve" smooth="yes"/>
-      <point x="553" y="12"/>
-      <point x="638" y="95"/>
-      <point x="638" y="193" type="curve"/>
-      <point x="651" y="193" type="line"/>
-      <point x="651" y="39"/>
-      <point x="499" y="-15"/>
-      <point x="396" y="-15" type="curve" smooth="yes"/>
-      <point x="183" y="-15"/>
-      <point x="43" y="113"/>
-      <point x="43" y="338" type="curve" smooth="yes"/>
-      <point x="43" y="521"/>
-      <point x="188" y="691"/>
-      <point x="384" y="691" type="curve" smooth="yes"/>
-      <point x="502" y="691"/>
-      <point x="568" y="648"/>
-      <point x="596" y="648" type="curve" smooth="yes"/>
-      <point x="610" y="648"/>
-      <point x="621" y="665"/>
-      <point x="623" y="675" type="curve"/>
-      <point x="634" y="675" type="line"/>
-      <point x="634" y="675"/>
+      <point x="639" y="465" type="line"/>
       <point x="639" y="465"/>
-      <point x="639" y="465" type="curve"/>
+      <point x="634" y="675"/>
+      <point x="634" y="675" type="curve"/>
+      <point x="623" y="675" type="line"/>
+      <point x="621" y="665"/>
+      <point x="610" y="648"/>
+      <point x="596" y="648" type="curve" smooth="yes"/>
+      <point x="568" y="648"/>
+      <point x="502" y="691"/>
+      <point x="384" y="691" type="curve" smooth="yes"/>
+      <point x="188" y="691"/>
+      <point x="43" y="521"/>
+      <point x="43" y="338" type="curve" smooth="yes"/>
+      <point x="43" y="113"/>
+      <point x="183" y="-15"/>
+      <point x="396" y="-15" type="curve" smooth="yes"/>
+      <point x="499" y="-15"/>
+      <point x="651" y="39"/>
+      <point x="651" y="193" type="curve"/>
+      <point x="638" y="193" type="line"/>
+      <point x="638" y="95"/>
+      <point x="553" y="12"/>
+      <point x="412" y="12" type="curve" smooth="yes"/>
+      <point x="261" y="12"/>
+      <point x="159" y="152"/>
+      <point x="159" y="338" type="curve" smooth="yes"/>
+      <point x="159" y="525"/>
+      <point x="262" y="678"/>
+      <point x="396" y="678" type="curve" smooth="yes"/>
+      <point x="508" y="678"/>
+      <point x="588" y="632"/>
+      <point x="630" y="465" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/E_uro.glif
+++ b/OpenBaskerville.ufo/glyphs/E_uro.glif
@@ -4,77 +4,77 @@
   <unicode hex="20AC"/>
   <outline>
     <contour>
-      <point x="630" y="465" type="line"/>
-      <point x="588" y="632"/>
-      <point x="528" y="678"/>
-      <point x="416" y="678" type="curve" smooth="yes"/>
-      <point x="291" y="678"/>
-      <point x="209" y="520"/>
-      <point x="209" y="333" type="curve" smooth="yes"/>
-      <point x="209" y="147"/>
-      <point x="281" y="14"/>
-      <point x="432" y="14" type="curve" smooth="yes"/>
-      <point x="562" y="14"/>
-      <point x="638" y="95"/>
-      <point x="638" y="193" type="curve"/>
-      <point x="651" y="193" type="line"/>
-      <point x="651" y="39"/>
-      <point x="514" y="-15"/>
-      <point x="416" y="-15" type="curve" smooth="yes"/>
-      <point x="203" y="-15"/>
-      <point x="93" y="123"/>
-      <point x="93" y="348" type="curve" smooth="yes"/>
-      <point x="93" y="531"/>
-      <point x="222" y="691"/>
-      <point x="404" y="691" type="curve" smooth="yes"/>
-      <point x="522" y="691"/>
-      <point x="568" y="648"/>
-      <point x="596" y="648" type="curve" smooth="yes"/>
-      <point x="610" y="648"/>
-      <point x="621" y="665"/>
-      <point x="623" y="675" type="curve"/>
-      <point x="634" y="675" type="line"/>
-      <point x="634" y="675"/>
+      <point x="639" y="465" type="line"/>
       <point x="639" y="465"/>
-      <point x="639" y="465" type="curve"/>
+      <point x="634" y="675"/>
+      <point x="634" y="675" type="curve"/>
+      <point x="623" y="675" type="line"/>
+      <point x="621" y="665"/>
+      <point x="610" y="648"/>
+      <point x="596" y="648" type="curve" smooth="yes"/>
+      <point x="568" y="648"/>
+      <point x="522" y="691"/>
+      <point x="404" y="691" type="curve" smooth="yes"/>
+      <point x="222" y="691"/>
+      <point x="93" y="531"/>
+      <point x="93" y="348" type="curve" smooth="yes"/>
+      <point x="93" y="123"/>
+      <point x="203" y="-15"/>
+      <point x="416" y="-15" type="curve" smooth="yes"/>
+      <point x="514" y="-15"/>
+      <point x="651" y="39"/>
+      <point x="651" y="193" type="curve"/>
+      <point x="638" y="193" type="line"/>
+      <point x="638" y="95"/>
+      <point x="562" y="14"/>
+      <point x="432" y="14" type="curve" smooth="yes"/>
+      <point x="281" y="14"/>
+      <point x="209" y="147"/>
+      <point x="209" y="333" type="curve" smooth="yes"/>
+      <point x="209" y="520"/>
+      <point x="291" y="678"/>
+      <point x="416" y="678" type="curve" smooth="yes"/>
+      <point x="528" y="678"/>
+      <point x="588" y="632"/>
+      <point x="630" y="465" type="curve"/>
     </contour>
     <contour>
-      <point x="41" y="402" type="line"/>
-      <point x="119" y="402" type="line"/>
-      <point x="119" y="402"/>
+      <point x="41" y="381" type="line"/>
+      <point x="41" y="381"/>
       <point x="116" y="381"/>
       <point x="116" y="381" type="curve"/>
       <point x="116" y="381"/>
-      <point x="41" y="381"/>
-      <point x="41" y="381" type="curve"/>
+      <point x="119" y="402"/>
+      <point x="119" y="402" type="curve"/>
+      <point x="41" y="402" type="line"/>
     </contour>
     <contour>
-      <point x="203" y="402" type="line"/>
-      <point x="203" y="402"/>
-      <point x="486" y="402"/>
-      <point x="486" y="402" type="curve"/>
-      <point x="486" y="381" type="line"/>
-      <point x="486" y="381"/>
+      <point x="201" y="381" type="line"/>
       <point x="201" y="381"/>
-      <point x="201" y="381" type="curve"/>
+      <point x="486" y="381"/>
+      <point x="486" y="381" type="curve"/>
+      <point x="486" y="402" type="line"/>
+      <point x="486" y="402"/>
+      <point x="203" y="402"/>
+      <point x="203" y="402" type="curve"/>
     </contour>
     <contour>
-      <point x="39" y="329" type="line"/>
-      <point x="113" y="329" type="line"/>
-      <point x="113" y="329"/>
+      <point x="39" y="308" type="line"/>
+      <point x="39" y="308"/>
       <point x="111" y="308"/>
       <point x="111" y="308" type="curve"/>
       <point x="111" y="308"/>
-      <point x="39" y="308"/>
-      <point x="39" y="308" type="curve"/>
+      <point x="113" y="329"/>
+      <point x="113" y="329" type="curve"/>
+      <point x="39" y="329" type="line"/>
     </contour>
     <contour>
-      <point x="194" y="329" type="line"/>
-      <point x="467" y="329" type="line"/>
-      <point x="467" y="308" type="line"/>
-      <point x="467" y="308"/>
+      <point x="195" y="308" type="line"/>
       <point x="195" y="308"/>
-      <point x="195" y="308" type="curve"/>
+      <point x="467" y="308"/>
+      <point x="467" y="308" type="curve"/>
+      <point x="467" y="329" type="line"/>
+      <point x="194" y="329" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/OpenBaskerville.ufo/glyphs/W_.glif
+++ b/OpenBaskerville.ufo/glyphs/W_.glif
@@ -4,61 +4,61 @@
   <unicode hex="0057"/>
   <outline>
     <contour>
-      <point x="550" y="539" type="line"/>
-      <point x="367" y="0" type="line"/>
-      <point x="356" y="0" type="line"/>
-      <point x="136" y="523" type="line" smooth="yes"/>
-      <point x="113" y="577"/>
-      <point x="78" y="663"/>
-      <point x="7" y="663" type="curve" smooth="yes"/>
-      <point x="-5" y="663" type="line"/>
-      <point x="-5" y="676" type="line"/>
-      <point x="310" y="676" type="line"/>
-      <point x="310" y="663" type="line"/>
-      <point x="298" y="663" type="line" smooth="yes"/>
-      <point x="236" y="663"/>
-      <point x="216" y="643"/>
-      <point x="216" y="610" type="curve" smooth="yes"/>
-      <point x="216" y="580"/>
-      <point x="236" y="534"/>
-      <point x="255" y="486" type="curve" smooth="yes"/>
-      <point x="396" y="137" type="line"/>
-      <point x="515" y="486" type="line"/>
-      <point x="524" y="511"/>
-      <point x="531" y="542"/>
-      <point x="531" y="565" type="curve" smooth="yes"/>
-      <point x="531" y="618"/>
-      <point x="507" y="663"/>
-      <point x="438" y="663" type="curve" smooth="yes"/>
-      <point x="426" y="663" type="line"/>
-      <point x="426" y="676" type="line"/>
-      <point x="740" y="676" type="line"/>
-      <point x="740" y="663" type="line"/>
-      <point x="728" y="663" type="line" smooth="yes"/>
-      <point x="659" y="663"/>
-      <point x="641" y="631"/>
-      <point x="641" y="594" type="curve" smooth="yes"/>
-      <point x="641" y="570"/>
-      <point x="648" y="545"/>
-      <point x="655" y="523" type="curve" smooth="yes"/>
-      <point x="782" y="137" type="line"/>
-      <point x="925" y="486" type="line" smooth="yes"/>
-      <point x="942" y="528"/>
-      <point x="954" y="566"/>
-      <point x="954" y="596" type="curve" smooth="yes"/>
-      <point x="954" y="637"/>
-      <point x="933" y="663"/>
-      <point x="880" y="663" type="curve" smooth="yes"/>
-      <point x="872" y="663" type="line"/>
-      <point x="872" y="676" type="line"/>
-      <point x="1098" y="676" type="line"/>
-      <point x="1098" y="663" type="line"/>
-      <point x="1090" y="663" type="line" smooth="yes"/>
-      <point x="1013" y="663"/>
-      <point x="996" y="614"/>
-      <point x="959" y="523" type="curve" smooth="yes"/>
-      <point x="745" y="0" type="line"/>
       <point x="734" y="0" type="line"/>
+      <point x="745" y="0" type="line"/>
+      <point x="959" y="523" type="line" smooth="yes"/>
+      <point x="996" y="614"/>
+      <point x="1013" y="663"/>
+      <point x="1090" y="663" type="curve" smooth="yes"/>
+      <point x="1098" y="663" type="line"/>
+      <point x="1098" y="676" type="line"/>
+      <point x="872" y="676" type="line"/>
+      <point x="872" y="663" type="line"/>
+      <point x="880" y="663" type="line" smooth="yes"/>
+      <point x="933" y="663"/>
+      <point x="954" y="637"/>
+      <point x="954" y="596" type="curve" smooth="yes"/>
+      <point x="954" y="566"/>
+      <point x="942" y="528"/>
+      <point x="925" y="486" type="curve" smooth="yes"/>
+      <point x="782" y="137" type="line"/>
+      <point x="655" y="523" type="line" smooth="yes"/>
+      <point x="648" y="545"/>
+      <point x="641" y="570"/>
+      <point x="641" y="594" type="curve" smooth="yes"/>
+      <point x="641" y="631"/>
+      <point x="659" y="663"/>
+      <point x="728" y="663" type="curve" smooth="yes"/>
+      <point x="740" y="663" type="line"/>
+      <point x="740" y="676" type="line"/>
+      <point x="426" y="676" type="line"/>
+      <point x="426" y="663" type="line"/>
+      <point x="438" y="663" type="line" smooth="yes"/>
+      <point x="507" y="663"/>
+      <point x="531" y="618"/>
+      <point x="531" y="565" type="curve" smooth="yes"/>
+      <point x="531" y="542"/>
+      <point x="524" y="511"/>
+      <point x="515" y="486" type="curve"/>
+      <point x="396" y="137" type="line"/>
+      <point x="255" y="486" type="line" smooth="yes"/>
+      <point x="236" y="534"/>
+      <point x="216" y="580"/>
+      <point x="216" y="610" type="curve" smooth="yes"/>
+      <point x="216" y="643"/>
+      <point x="236" y="663"/>
+      <point x="298" y="663" type="curve" smooth="yes"/>
+      <point x="310" y="663" type="line"/>
+      <point x="310" y="676" type="line"/>
+      <point x="-5" y="676" type="line"/>
+      <point x="-5" y="663" type="line"/>
+      <point x="7" y="663" type="line" smooth="yes"/>
+      <point x="78" y="663"/>
+      <point x="113" y="577"/>
+      <point x="136" y="523" type="curve" smooth="yes"/>
+      <point x="356" y="0" type="line"/>
+      <point x="367" y="0" type="line"/>
+      <point x="550" y="539" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/asciitilde.glif
+++ b/OpenBaskerville.ufo/glyphs/asciitilde.glif
@@ -4,26 +4,26 @@
   <unicode hex="007E"/>
   <outline>
     <contour>
-      <point x="316" y="253" type="line"/>
-      <point x="316" y="211"/>
-      <point x="278" y="168"/>
-      <point x="232" y="168" type="curve"/>
-      <point x="174" y="168"/>
-      <point x="139" y="208"/>
-      <point x="85" y="208" type="curve"/>
-      <point x="50" y="208"/>
-      <point x="38" y="173"/>
-      <point x="38" y="173" type="curve"/>
-      <point x="18" y="173" type="line"/>
-      <point x="18" y="226"/>
-      <point x="66" y="257"/>
-      <point x="100" y="257" type="curve"/>
-      <point x="155" y="257"/>
-      <point x="199" y="218"/>
-      <point x="239" y="218" type="curve"/>
-      <point x="284" y="218"/>
+      <point x="301" y="255" type="line"/>
       <point x="301" y="237"/>
-      <point x="301" y="255" type="curve"/>
+      <point x="284" y="218"/>
+      <point x="239" y="218" type="curve"/>
+      <point x="199" y="218"/>
+      <point x="155" y="257"/>
+      <point x="100" y="257" type="curve"/>
+      <point x="66" y="257"/>
+      <point x="18" y="226"/>
+      <point x="18" y="173" type="curve"/>
+      <point x="38" y="173" type="line"/>
+      <point x="38" y="173"/>
+      <point x="50" y="208"/>
+      <point x="85" y="208" type="curve"/>
+      <point x="139" y="208"/>
+      <point x="174" y="168"/>
+      <point x="232" y="168" type="curve"/>
+      <point x="278" y="168"/>
+      <point x="316" y="211"/>
+      <point x="316" y="253" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/c_t.glif
+++ b/OpenBaskerville.ufo/glyphs/c_t.glif
@@ -3,79 +3,79 @@
   <advance width="739"/>
   <outline>
     <contour>
-      <point x="483" y="419" type="line"/>
-      <point x="568" y="431"/>
-      <point x="593" y="495"/>
-      <point x="593" y="548" type="curve" smooth="yes"/>
-      <point x="593" y="649"/>
-      <point x="486" y="680"/>
-      <point x="392" y="680" type="curve" smooth="yes"/>
-      <point x="265" y="680"/>
-      <point x="194" y="621"/>
-      <point x="194" y="548" type="curve" smooth="yes"/>
-      <point x="194" y="476"/>
-      <point x="275" y="437"/>
-      <point x="326" y="424" type="curve" smooth="yes"/>
-      <point x="370" y="413"/>
-      <point x="398" y="390"/>
-      <point x="398" y="357" type="curve" smooth="yes"/>
-      <point x="398" y="335"/>
-      <point x="384" y="320"/>
-      <point x="362" y="320" type="curve" smooth="yes"/>
-      <point x="340" y="320"/>
-      <point x="324" y="334"/>
-      <point x="320" y="354" type="curve" smooth="yes"/>
-      <point x="310" y="405"/>
-      <point x="301" y="418"/>
-      <point x="245" y="418" type="curve" smooth="yes"/>
-      <point x="163" y="418"/>
-      <point x="115" y="325"/>
-      <point x="115" y="210" type="curve" smooth="yes"/>
-      <point x="115" y="95"/>
-      <point x="156" y="13"/>
-      <point x="277" y="13" type="curve" smooth="yes"/>
-      <point x="365" y="13"/>
-      <point x="388" y="51"/>
-      <point x="401" y="100" type="curve"/>
-      <point x="412" y="100" type="line"/>
-      <point x="403" y="37"/>
-      <point x="365" y="-14"/>
-      <point x="254" y="-14" type="curve" smooth="yes"/>
-      <point x="109" y="-14"/>
-      <point x="35" y="79"/>
-      <point x="35" y="210" type="curve" smooth="yes"/>
-      <point x="35" y="334"/>
-      <point x="121" y="434"/>
-      <point x="255" y="434" type="curve"/>
-      <point x="227" y="449"/>
-      <point x="178" y="487"/>
-      <point x="178" y="548" type="curve" smooth="yes"/>
-      <point x="178" y="631"/>
-      <point x="255" y="694"/>
-      <point x="392" y="694" type="curve" smooth="yes"/>
-      <point x="485" y="694"/>
-      <point x="610" y="670"/>
-      <point x="610" y="539" type="curve" smooth="yes"/>
-      <point x="610" y="421" type="line"/>
-      <point x="727" y="421" type="line"/>
-      <point x="727" y="405" type="line"/>
-      <point x="610" y="405" type="line"/>
-      <point x="610" y="134" type="line" smooth="yes"/>
-      <point x="610" y="41"/>
-      <point x="623" y="7"/>
-      <point x="670" y="7" type="curve" smooth="yes"/>
-      <point x="718" y="7"/>
-      <point x="734" y="35"/>
-      <point x="741" y="47" type="curve"/>
-      <point x="749" y="42" type="line"/>
-      <point x="741" y="31"/>
-      <point x="731" y="-14"/>
-      <point x="639" y="-14" type="curve" smooth="yes"/>
-      <point x="574" y="-14"/>
-      <point x="533" y="17"/>
-      <point x="535" y="88" type="curve" smooth="yes"/>
-      <point x="543" y="405" type="line"/>
       <point x="483" y="405" type="line"/>
+      <point x="543" y="405" type="line"/>
+      <point x="535" y="88" type="line" smooth="yes"/>
+      <point x="533" y="17"/>
+      <point x="574" y="-14"/>
+      <point x="639" y="-14" type="curve" smooth="yes"/>
+      <point x="731" y="-14"/>
+      <point x="741" y="31"/>
+      <point x="749" y="42" type="curve"/>
+      <point x="741" y="47" type="line"/>
+      <point x="734" y="35"/>
+      <point x="718" y="7"/>
+      <point x="670" y="7" type="curve" smooth="yes"/>
+      <point x="623" y="7"/>
+      <point x="610" y="41"/>
+      <point x="610" y="134" type="curve" smooth="yes"/>
+      <point x="610" y="405" type="line"/>
+      <point x="727" y="405" type="line"/>
+      <point x="727" y="421" type="line"/>
+      <point x="610" y="421" type="line"/>
+      <point x="610" y="539" type="line" smooth="yes"/>
+      <point x="610" y="670"/>
+      <point x="485" y="694"/>
+      <point x="392" y="694" type="curve" smooth="yes"/>
+      <point x="255" y="694"/>
+      <point x="178" y="631"/>
+      <point x="178" y="548" type="curve" smooth="yes"/>
+      <point x="178" y="487"/>
+      <point x="227" y="449"/>
+      <point x="255" y="434" type="curve"/>
+      <point x="121" y="434"/>
+      <point x="35" y="334"/>
+      <point x="35" y="210" type="curve" smooth="yes"/>
+      <point x="35" y="79"/>
+      <point x="109" y="-14"/>
+      <point x="254" y="-14" type="curve" smooth="yes"/>
+      <point x="365" y="-14"/>
+      <point x="403" y="37"/>
+      <point x="412" y="100" type="curve"/>
+      <point x="401" y="100" type="line"/>
+      <point x="388" y="51"/>
+      <point x="365" y="13"/>
+      <point x="277" y="13" type="curve" smooth="yes"/>
+      <point x="156" y="13"/>
+      <point x="115" y="95"/>
+      <point x="115" y="210" type="curve" smooth="yes"/>
+      <point x="115" y="325"/>
+      <point x="163" y="418"/>
+      <point x="245" y="418" type="curve" smooth="yes"/>
+      <point x="301" y="418"/>
+      <point x="310" y="405"/>
+      <point x="320" y="354" type="curve" smooth="yes"/>
+      <point x="324" y="334"/>
+      <point x="340" y="320"/>
+      <point x="362" y="320" type="curve" smooth="yes"/>
+      <point x="384" y="320"/>
+      <point x="398" y="335"/>
+      <point x="398" y="357" type="curve" smooth="yes"/>
+      <point x="398" y="390"/>
+      <point x="370" y="413"/>
+      <point x="326" y="424" type="curve" smooth="yes"/>
+      <point x="275" y="437"/>
+      <point x="194" y="476"/>
+      <point x="194" y="548" type="curve" smooth="yes"/>
+      <point x="194" y="621"/>
+      <point x="265" y="680"/>
+      <point x="392" y="680" type="curve" smooth="yes"/>
+      <point x="486" y="680"/>
+      <point x="593" y="649"/>
+      <point x="593" y="548" type="curve" smooth="yes"/>
+      <point x="593" y="495"/>
+      <point x="568" y="431"/>
+      <point x="483" y="419" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/OpenBaskerville.ufo/glyphs/caron.glif
+++ b/OpenBaskerville.ufo/glyphs/caron.glif
@@ -7,13 +7,13 @@
       <point x="172" y="0" type="move" name="_top"/>
     </contour>
     <contour>
-      <point x="269" y="658" type="line"/>
-      <point x="309" y="658" type="line"/>
-      <point x="195" y="495" type="line"/>
-      <point x="149" y="495" type="line"/>
-      <point x="35" y="658" type="line"/>
-      <point x="75" y="658" type="line"/>
       <point x="172" y="566" type="line"/>
+      <point x="75" y="658" type="line"/>
+      <point x="35" y="658" type="line"/>
+      <point x="149" y="495" type="line"/>
+      <point x="195" y="495" type="line"/>
+      <point x="309" y="658" type="line"/>
+      <point x="269" y="658" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/eight.glif
+++ b/OpenBaskerville.ufo/glyphs/eight.glif
@@ -4,58 +4,58 @@
   <unicode hex="0038"/>
   <outline>
     <contour>
-      <point x="458" y="174" type="curve" smooth="yes"/>
-      <point x="458" y="28"/>
-      <point x="331" y="-14"/>
-      <point x="247" y="-14" type="curve" smooth="yes"/>
-      <point x="181" y="-14"/>
-      <point x="40" y="32"/>
-      <point x="40" y="157" type="curve" smooth="yes"/>
-      <point x="40" y="280"/>
-      <point x="146" y="326"/>
-      <point x="192" y="342" type="curve"/>
-      <point x="119" y="379"/>
-      <point x="53" y="422"/>
-      <point x="53" y="516" type="curve" smooth="yes"/>
-      <point x="53" y="669"/>
-      <point x="186" y="689"/>
-      <point x="241" y="689" type="curve" smooth="yes"/>
-      <point x="331" y="689"/>
-      <point x="424" y="648"/>
-      <point x="424" y="541" type="curve" smooth="yes"/>
-      <point x="424" y="441"/>
-      <point x="342" y="395"/>
-      <point x="299" y="375" type="curve"/>
-      <point x="381" y="336"/>
       <point x="458" y="289"/>
+      <point x="381" y="336"/>
+      <point x="299" y="375" type="curve"/>
+      <point x="342" y="395"/>
+      <point x="424" y="441"/>
+      <point x="424" y="541" type="curve" smooth="yes"/>
+      <point x="424" y="648"/>
+      <point x="331" y="689"/>
+      <point x="241" y="689" type="curve" smooth="yes"/>
+      <point x="186" y="689"/>
+      <point x="53" y="669"/>
+      <point x="53" y="516" type="curve" smooth="yes"/>
+      <point x="53" y="422"/>
+      <point x="119" y="379"/>
+      <point x="192" y="342" type="curve"/>
+      <point x="146" y="326"/>
+      <point x="40" y="280"/>
+      <point x="40" y="157" type="curve" smooth="yes"/>
+      <point x="40" y="32"/>
+      <point x="181" y="-14"/>
+      <point x="247" y="-14" type="curve" smooth="yes"/>
+      <point x="331" y="-14"/>
+      <point x="458" y="28"/>
+      <point x="458" y="174" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="119" y="159" type="curve" smooth="yes"/>
-      <point x="119" y="17"/>
-      <point x="218" y="2"/>
-      <point x="257" y="2" type="curve" smooth="yes"/>
-      <point x="296" y="2"/>
-      <point x="385" y="24"/>
-      <point x="385" y="146" type="curve" smooth="yes"/>
-      <point x="385" y="248"/>
-      <point x="296" y="295"/>
-      <point x="206" y="335" type="curve"/>
-      <point x="177" y="314"/>
       <point x="119" y="251"/>
+      <point x="177" y="314"/>
+      <point x="206" y="335" type="curve"/>
+      <point x="296" y="295"/>
+      <point x="385" y="248"/>
+      <point x="385" y="146" type="curve" smooth="yes"/>
+      <point x="385" y="24"/>
+      <point x="296" y="2"/>
+      <point x="257" y="2" type="curve" smooth="yes"/>
+      <point x="218" y="2"/>
+      <point x="119" y="17"/>
+      <point x="119" y="159" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="352" y="535" type="curve" smooth="yes"/>
-      <point x="352" y="645"/>
-      <point x="287" y="674"/>
-      <point x="229" y="674" type="curve" smooth="yes"/>
-      <point x="132" y="674"/>
-      <point x="120" y="604"/>
-      <point x="120" y="558" type="curve" smooth="yes"/>
-      <point x="120" y="454"/>
-      <point x="192" y="419"/>
-      <point x="282" y="383" type="curve"/>
-      <point x="313" y="403"/>
       <point x="352" y="432"/>
+      <point x="313" y="403"/>
+      <point x="282" y="383" type="curve"/>
+      <point x="192" y="419"/>
+      <point x="120" y="454"/>
+      <point x="120" y="558" type="curve" smooth="yes"/>
+      <point x="120" y="604"/>
+      <point x="132" y="674"/>
+      <point x="229" y="674" type="curve" smooth="yes"/>
+      <point x="287" y="674"/>
+      <point x="352" y="645"/>
+      <point x="352" y="535" type="curve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/ff.glif
+++ b/OpenBaskerville.ufo/glyphs/ff.glif
@@ -4,78 +4,78 @@
   <unicode hex="FB00"/>
   <outline>
     <contour>
-      <point x="517" y="694" type="curve" smooth="yes"/>
-      <point x="538" y="694"/>
-      <point x="586" y="692"/>
-      <point x="618" y="660" type="curve" smooth="yes"/>
-      <point x="635" y="643"/>
-      <point x="626" y="602"/>
-      <point x="595" y="602" type="curve" smooth="yes"/>
-      <point x="573" y="602"/>
-      <point x="569" y="618"/>
-      <point x="559" y="639" type="curve" smooth="yes"/>
-      <point x="537" y="685"/>
-      <point x="528" y="686"/>
-      <point x="509" y="686" type="curve" smooth="yes"/>
-      <point x="490" y="686"/>
-      <point x="442" y="682"/>
-      <point x="442" y="549" type="curve" smooth="yes"/>
-      <point x="442" y="421" type="line"/>
-      <point x="570" y="421" type="line"/>
-      <point x="570" y="401" type="line"/>
-      <point x="442" y="401" type="line"/>
-      <point x="442" y="133" type="line" smooth="yes"/>
-      <point x="442" y="40"/>
-      <point x="444" y="13"/>
-      <point x="508" y="13" type="curve"/>
-      <point x="508" y="0" type="line"/>
-      <point x="308" y="0" type="line"/>
-      <point x="308" y="13" type="line"/>
-      <point x="372" y="13"/>
-      <point x="376" y="45"/>
-      <point x="376" y="133" type="curve" smooth="yes"/>
-      <point x="376" y="401" type="line"/>
-      <point x="175" y="401" type="line"/>
-      <point x="175" y="133" type="line" smooth="yes"/>
-      <point x="175" y="40"/>
-      <point x="177" y="13"/>
-      <point x="241" y="13" type="curve"/>
-      <point x="241" y="0" type="line"/>
-      <point x="41" y="0" type="line"/>
-      <point x="41" y="13" type="line"/>
-      <point x="105" y="13"/>
-      <point x="109" y="45"/>
-      <point x="109" y="133" type="curve" smooth="yes"/>
-      <point x="109" y="401" type="line"/>
-      <point x="30" y="401" type="line"/>
-      <point x="30" y="421" type="line"/>
-      <point x="109" y="421" type="line"/>
-      <point x="109" y="549" type="line" smooth="yes"/>
-      <point x="109" y="587"/>
-      <point x="140" y="694"/>
-      <point x="288" y="694" type="curve" smooth="yes"/>
-      <point x="323" y="694"/>
-      <point x="397" y="686"/>
-      <point x="408" y="646" type="curve"/>
-      <point x="429" y="673"/>
       <point x="464" y="694"/>
+      <point x="429" y="673"/>
+      <point x="408" y="646" type="curve"/>
+      <point x="397" y="686"/>
+      <point x="323" y="694"/>
+      <point x="288" y="694" type="curve" smooth="yes"/>
+      <point x="140" y="694"/>
+      <point x="109" y="587"/>
+      <point x="109" y="549" type="curve" smooth="yes"/>
+      <point x="109" y="421" type="line"/>
+      <point x="30" y="421" type="line"/>
+      <point x="30" y="401" type="line"/>
+      <point x="109" y="401" type="line"/>
+      <point x="109" y="133" type="line" smooth="yes"/>
+      <point x="109" y="45"/>
+      <point x="105" y="13"/>
+      <point x="41" y="13" type="curve"/>
+      <point x="41" y="0" type="line"/>
+      <point x="241" y="0" type="line"/>
+      <point x="241" y="13" type="line"/>
+      <point x="177" y="13"/>
+      <point x="175" y="40"/>
+      <point x="175" y="133" type="curve" smooth="yes"/>
+      <point x="175" y="401" type="line"/>
+      <point x="376" y="401" type="line"/>
+      <point x="376" y="133" type="line" smooth="yes"/>
+      <point x="376" y="45"/>
+      <point x="372" y="13"/>
+      <point x="308" y="13" type="curve"/>
+      <point x="308" y="0" type="line"/>
+      <point x="508" y="0" type="line"/>
+      <point x="508" y="13" type="line"/>
+      <point x="444" y="13"/>
+      <point x="442" y="40"/>
+      <point x="442" y="133" type="curve" smooth="yes"/>
+      <point x="442" y="401" type="line"/>
+      <point x="570" y="401" type="line"/>
+      <point x="570" y="421" type="line"/>
+      <point x="442" y="421" type="line"/>
+      <point x="442" y="549" type="line" smooth="yes"/>
+      <point x="442" y="682"/>
+      <point x="490" y="686"/>
+      <point x="509" y="686" type="curve" smooth="yes"/>
+      <point x="528" y="686"/>
+      <point x="537" y="685"/>
+      <point x="559" y="639" type="curve" smooth="yes"/>
+      <point x="569" y="618"/>
+      <point x="573" y="602"/>
+      <point x="595" y="602" type="curve" smooth="yes"/>
+      <point x="626" y="602"/>
+      <point x="635" y="643"/>
+      <point x="618" y="660" type="curve" smooth="yes"/>
+      <point x="586" y="692"/>
+      <point x="538" y="694"/>
+      <point x="517" y="694" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="376" y="549" type="line"/>
-      <point x="376" y="561"/>
-      <point x="378" y="581"/>
-      <point x="385" y="603" type="curve"/>
-      <point x="360" y="597"/>
-      <point x="352" y="619"/>
-      <point x="343" y="639" type="curve" smooth="yes"/>
-      <point x="321" y="685"/>
-      <point x="306" y="686"/>
-      <point x="288" y="686" type="curve" smooth="yes"/>
-      <point x="269" y="686"/>
-      <point x="175" y="682"/>
-      <point x="175" y="549" type="curve" smooth="yes"/>
-      <point x="175" y="421" type="line"/>
       <point x="376" y="421" type="line"/>
+      <point x="175" y="421" type="line"/>
+      <point x="175" y="549" type="line" smooth="yes"/>
+      <point x="175" y="682"/>
+      <point x="269" y="686"/>
+      <point x="288" y="686" type="curve" smooth="yes"/>
+      <point x="306" y="686"/>
+      <point x="321" y="685"/>
+      <point x="343" y="639" type="curve" smooth="yes"/>
+      <point x="352" y="619"/>
+      <point x="360" y="597"/>
+      <point x="385" y="603" type="curve"/>
+      <point x="378" y="581"/>
+      <point x="376" y="561"/>
+      <point x="376" y="549" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/ffl.glif
+++ b/OpenBaskerville.ufo/glyphs/ffl.glif
@@ -4,90 +4,90 @@
   <unicode hex="FB04"/>
   <outline>
     <contour>
-      <point x="376" y="549" type="line"/>
-      <point x="376" y="561"/>
-      <point x="378" y="581"/>
-      <point x="385" y="603" type="curve"/>
-      <point x="360" y="597"/>
-      <point x="352" y="619"/>
-      <point x="343" y="639" type="curve" smooth="yes"/>
-      <point x="321" y="685"/>
-      <point x="306" y="686"/>
-      <point x="288" y="686" type="curve" smooth="yes"/>
-      <point x="269" y="686"/>
-      <point x="175" y="682"/>
-      <point x="175" y="549" type="curve" smooth="yes"/>
-      <point x="175" y="421" type="line"/>
       <point x="376" y="421" type="line"/>
+      <point x="175" y="421" type="line"/>
+      <point x="175" y="549" type="line" smooth="yes"/>
+      <point x="175" y="682"/>
+      <point x="269" y="686"/>
+      <point x="288" y="686" type="curve" smooth="yes"/>
+      <point x="306" y="686"/>
+      <point x="321" y="685"/>
+      <point x="343" y="639" type="curve" smooth="yes"/>
+      <point x="352" y="619"/>
+      <point x="360" y="597"/>
+      <point x="385" y="603" type="curve"/>
+      <point x="378" y="581"/>
+      <point x="376" y="561"/>
+      <point x="376" y="549" type="curve"/>
     </contour>
     <contour>
-      <point x="408" y="646" type="curve"/>
-      <point x="433" y="674"/>
-      <point x="477" y="694"/>
-      <point x="547" y="694" type="curve" smooth="yes"/>
-      <point x="578" y="694"/>
-      <point x="637" y="691"/>
-      <point x="670" y="660" type="curve"/>
-      <point x="685" y="674"/>
-      <point x="703" y="691"/>
-      <point x="703" y="691" type="curve"/>
-      <point x="713" y="691" type="line"/>
-      <point x="712" y="133" type="line" smooth="yes"/>
-      <point x="712" y="40"/>
-      <point x="714" y="13"/>
-      <point x="778" y="13" type="curve"/>
-      <point x="778" y="0" type="line"/>
-      <point x="578" y="0" type="line"/>
-      <point x="578" y="13" type="line"/>
-      <point x="642" y="13"/>
-      <point x="646" y="45"/>
-      <point x="646" y="133" type="curve" smooth="yes"/>
-      <point x="646" y="596" type="line"/>
-      <point x="628" y="599"/>
-      <point x="616" y="617"/>
-      <point x="607" y="636" type="curve" smooth="yes"/>
-      <point x="585" y="682"/>
-      <point x="582" y="686"/>
-      <point x="547" y="686" type="curve" smooth="yes"/>
-      <point x="506" y="686"/>
-      <point x="442" y="659"/>
-      <point x="442" y="549" type="curve"/>
-      <point x="442" y="421" type="line"/>
-      <point x="570" y="421" type="line"/>
-      <point x="570" y="401" type="line"/>
-      <point x="442" y="401" type="line"/>
-      <point x="442" y="133" type="line" smooth="yes"/>
-      <point x="442" y="40"/>
-      <point x="444" y="13"/>
-      <point x="508" y="13" type="curve"/>
-      <point x="508" y="0" type="line"/>
-      <point x="308" y="0" type="line"/>
-      <point x="308" y="13" type="line"/>
-      <point x="372" y="13"/>
-      <point x="376" y="45"/>
-      <point x="376" y="133" type="curve" smooth="yes"/>
-      <point x="376" y="401" type="line"/>
-      <point x="175" y="401" type="line"/>
-      <point x="175" y="133" type="line" smooth="yes"/>
-      <point x="175" y="40"/>
-      <point x="177" y="13"/>
-      <point x="241" y="13" type="curve"/>
-      <point x="241" y="0" type="line"/>
-      <point x="41" y="0" type="line"/>
-      <point x="41" y="13" type="line"/>
-      <point x="105" y="13"/>
-      <point x="109" y="45"/>
-      <point x="109" y="133" type="curve" smooth="yes"/>
-      <point x="109" y="401" type="line"/>
-      <point x="30" y="401" type="line"/>
-      <point x="30" y="421" type="line"/>
-      <point x="109" y="421" type="line"/>
-      <point x="109" y="549" type="line" smooth="yes"/>
-      <point x="109" y="587"/>
-      <point x="140" y="694"/>
-      <point x="288" y="694" type="curve" smooth="yes"/>
-      <point x="323" y="694"/>
       <point x="397" y="686"/>
+      <point x="323" y="694"/>
+      <point x="288" y="694" type="curve" smooth="yes"/>
+      <point x="140" y="694"/>
+      <point x="109" y="587"/>
+      <point x="109" y="549" type="curve" smooth="yes"/>
+      <point x="109" y="421" type="line"/>
+      <point x="30" y="421" type="line"/>
+      <point x="30" y="401" type="line"/>
+      <point x="109" y="401" type="line"/>
+      <point x="109" y="133" type="line" smooth="yes"/>
+      <point x="109" y="45"/>
+      <point x="105" y="13"/>
+      <point x="41" y="13" type="curve"/>
+      <point x="41" y="0" type="line"/>
+      <point x="241" y="0" type="line"/>
+      <point x="241" y="13" type="line"/>
+      <point x="177" y="13"/>
+      <point x="175" y="40"/>
+      <point x="175" y="133" type="curve" smooth="yes"/>
+      <point x="175" y="401" type="line"/>
+      <point x="376" y="401" type="line"/>
+      <point x="376" y="133" type="line" smooth="yes"/>
+      <point x="376" y="45"/>
+      <point x="372" y="13"/>
+      <point x="308" y="13" type="curve"/>
+      <point x="308" y="0" type="line"/>
+      <point x="508" y="0" type="line"/>
+      <point x="508" y="13" type="line"/>
+      <point x="444" y="13"/>
+      <point x="442" y="40"/>
+      <point x="442" y="133" type="curve" smooth="yes"/>
+      <point x="442" y="401" type="line"/>
+      <point x="570" y="401" type="line"/>
+      <point x="570" y="421" type="line"/>
+      <point x="442" y="421" type="line"/>
+      <point x="442" y="549" type="line"/>
+      <point x="442" y="659"/>
+      <point x="506" y="686"/>
+      <point x="547" y="686" type="curve" smooth="yes"/>
+      <point x="582" y="686"/>
+      <point x="585" y="682"/>
+      <point x="607" y="636" type="curve" smooth="yes"/>
+      <point x="616" y="617"/>
+      <point x="628" y="599"/>
+      <point x="646" y="596" type="curve"/>
+      <point x="646" y="133" type="line" smooth="yes"/>
+      <point x="646" y="45"/>
+      <point x="642" y="13"/>
+      <point x="578" y="13" type="curve"/>
+      <point x="578" y="0" type="line"/>
+      <point x="778" y="0" type="line"/>
+      <point x="778" y="13" type="line"/>
+      <point x="714" y="13"/>
+      <point x="712" y="40"/>
+      <point x="712" y="133" type="curve" smooth="yes"/>
+      <point x="713" y="691" type="line"/>
+      <point x="703" y="691" type="line"/>
+      <point x="703" y="691"/>
+      <point x="685" y="674"/>
+      <point x="670" y="660" type="curve"/>
+      <point x="637" y="691"/>
+      <point x="578" y="694"/>
+      <point x="547" y="694" type="curve" smooth="yes"/>
+      <point x="477" y="694"/>
+      <point x="433" y="674"/>
+      <point x="408" y="646" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/hyphen.glif
+++ b/OpenBaskerville.ufo/glyphs/hyphen.glif
@@ -4,16 +4,16 @@
   <unicode hex="002D"/>
   <outline>
     <contour>
-      <point x="272" y="239" type="line"/>
-      <point x="272" y="239"/>
-      <point x="266" y="190"/>
-      <point x="266" y="190" type="curve"/>
-      <point x="266" y="190"/>
+      <point x="48" y="236" type="line"/>
+      <point x="49" y="219"/>
       <point x="48" y="193"/>
       <point x="48" y="193" type="curve" smooth="yes"/>
       <point x="48" y="193"/>
-      <point x="49" y="219"/>
-      <point x="48" y="236" type="curve"/>
+      <point x="266" y="190"/>
+      <point x="266" y="190" type="curve"/>
+      <point x="266" y="190"/>
+      <point x="272" y="239"/>
+      <point x="272" y="239" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/parenleft.glif
+++ b/OpenBaskerville.ufo/glyphs/parenleft.glif
@@ -4,20 +4,20 @@
   <unicode hex="0028"/>
   <outline>
     <contour>
-      <point x="275" y="694" type="curve"/>
-      <point x="275" y="661" type="line"/>
-      <point x="275" y="661"/>
-      <point x="81" y="570"/>
-      <point x="81" y="242" type="curve" smooth="yes"/>
-      <point x="81" y="54"/>
-      <point x="220" y="-89"/>
-      <point x="275" y="-126" type="curve"/>
-      <point x="275" y="-157" type="line"/>
-      <point x="226" y="-159"/>
-      <point x="0" y="27"/>
-      <point x="0" y="242" type="curve" smooth="yes"/>
-      <point x="0" y="528"/>
       <point x="256" y="694"/>
+      <point x="0" y="528"/>
+      <point x="0" y="242" type="curve" smooth="yes"/>
+      <point x="0" y="27"/>
+      <point x="226" y="-159"/>
+      <point x="275" y="-157" type="curve"/>
+      <point x="275" y="-126" type="line"/>
+      <point x="220" y="-89"/>
+      <point x="81" y="54"/>
+      <point x="81" y="242" type="curve" smooth="yes"/>
+      <point x="81" y="570"/>
+      <point x="275" y="661"/>
+      <point x="275" y="661" type="curve"/>
+      <point x="275" y="694" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/sterling.glif
+++ b/OpenBaskerville.ufo/glyphs/sterling.glif
@@ -4,102 +4,102 @@
   <unicode hex="00A3"/>
   <outline>
     <contour>
-      <point x="224" y="231" type="line"/>
-      <point x="340" y="231" type="line"/>
-      <point x="342" y="245"/>
-      <point x="343" y="261"/>
-      <point x="344" y="280" type="curve"/>
-      <point x="236" y="280" type="line"/>
-      <point x="236" y="299" type="line"/>
-      <point x="345" y="299" type="line"/>
-      <point x="345" y="334" type="line" smooth="yes"/>
-      <point x="345" y="519"/>
-      <point x="443" y="686"/>
-      <point x="591" y="686" type="curve" smooth="yes"/>
-      <point x="696" y="686"/>
-      <point x="751" y="642"/>
-      <point x="751" y="564" type="curve" smooth="yes"/>
-      <point x="751" y="485"/>
-      <point x="687" y="432"/>
-      <point x="620" y="432" type="curve" smooth="yes"/>
-      <point x="581" y="432"/>
-      <point x="558" y="448"/>
-      <point x="551" y="457" type="curve"/>
-      <point x="558" y="466" type="line"/>
-      <point x="565" y="461"/>
-      <point x="586" y="451"/>
-      <point x="614" y="451" type="curve" smooth="yes"/>
-      <point x="663" y="451"/>
-      <point x="691" y="518"/>
-      <point x="691" y="566" type="curve" smooth="yes"/>
-      <point x="691" y="618"/>
-      <point x="653" y="671"/>
-      <point x="591" y="671" type="curve" smooth="yes"/>
-      <point x="498" y="671"/>
-      <point x="434" y="558"/>
-      <point x="434" y="374" type="curve" smooth="yes"/>
-      <point x="434" y="346"/>
-      <point x="432" y="321"/>
-      <point x="429" y="298" type="curve"/>
-      <point x="448" y="298"/>
-      <point x="544" y="299"/>
-      <point x="544" y="299" type="curve"/>
-      <point x="543" y="280" type="line"/>
-      <point x="426" y="280" type="line"/>
-      <point x="423" y="262"/>
-      <point x="419" y="246"/>
-      <point x="415" y="230" type="curve"/>
-      <point x="439" y="230"/>
-      <point x="532" y="231"/>
-      <point x="532" y="231" type="curve"/>
-      <point x="531" y="212" type="line"/>
-      <point x="408" y="212" type="line"/>
-      <point x="393" y="169"/>
-      <point x="371" y="133"/>
-      <point x="345" y="98" type="curve"/>
-      <point x="423" y="75"/>
-      <point x="504" y="50"/>
-      <point x="552" y="50" type="curve" smooth="yes"/>
-      <point x="623" y="50"/>
-      <point x="677" y="79"/>
-      <point x="694" y="137" type="curve"/>
-      <point x="709" y="137" type="line"/>
-      <point x="709" y="69"/>
-      <point x="644" y="-6"/>
-      <point x="554" y="-6" type="curve" smooth="yes"/>
-      <point x="490" y="-6"/>
-      <point x="400" y="32"/>
-      <point x="322" y="70" type="curve"/>
-      <point x="278" y="22"/>
-      <point x="221" y="-7"/>
-      <point x="157" y="-7" type="curve" smooth="yes"/>
-      <point x="92" y="-7"/>
-      <point x="28" y="16"/>
-      <point x="28" y="63" type="curve" smooth="yes"/>
-      <point x="28" y="105"/>
-      <point x="83" y="134"/>
-      <point x="179" y="134" type="curve" smooth="yes"/>
-      <point x="209" y="134"/>
-      <point x="252" y="124"/>
-      <point x="299" y="111" type="curve"/>
-      <point x="318" y="146"/>
-      <point x="330" y="174"/>
-      <point x="337" y="212" type="curve"/>
       <point x="224" y="212" type="line"/>
+      <point x="337" y="212" type="line"/>
+      <point x="330" y="174"/>
+      <point x="318" y="146"/>
+      <point x="299" y="111" type="curve"/>
+      <point x="252" y="124"/>
+      <point x="209" y="134"/>
+      <point x="179" y="134" type="curve" smooth="yes"/>
+      <point x="83" y="134"/>
+      <point x="28" y="105"/>
+      <point x="28" y="63" type="curve" smooth="yes"/>
+      <point x="28" y="16"/>
+      <point x="92" y="-7"/>
+      <point x="157" y="-7" type="curve" smooth="yes"/>
+      <point x="221" y="-7"/>
+      <point x="278" y="22"/>
+      <point x="322" y="70" type="curve"/>
+      <point x="400" y="32"/>
+      <point x="490" y="-6"/>
+      <point x="554" y="-6" type="curve" smooth="yes"/>
+      <point x="644" y="-6"/>
+      <point x="709" y="69"/>
+      <point x="709" y="137" type="curve"/>
+      <point x="694" y="137" type="line"/>
+      <point x="677" y="79"/>
+      <point x="623" y="50"/>
+      <point x="552" y="50" type="curve" smooth="yes"/>
+      <point x="504" y="50"/>
+      <point x="423" y="75"/>
+      <point x="345" y="98" type="curve"/>
+      <point x="371" y="133"/>
+      <point x="393" y="169"/>
+      <point x="408" y="212" type="curve"/>
+      <point x="531" y="212" type="line"/>
+      <point x="532" y="231" type="line"/>
+      <point x="532" y="231"/>
+      <point x="439" y="230"/>
+      <point x="415" y="230" type="curve"/>
+      <point x="419" y="246"/>
+      <point x="423" y="262"/>
+      <point x="426" y="280" type="curve"/>
+      <point x="543" y="280" type="line"/>
+      <point x="544" y="299" type="line"/>
+      <point x="544" y="299"/>
+      <point x="448" y="298"/>
+      <point x="429" y="298" type="curve"/>
+      <point x="432" y="321"/>
+      <point x="434" y="346"/>
+      <point x="434" y="374" type="curve" smooth="yes"/>
+      <point x="434" y="558"/>
+      <point x="498" y="671"/>
+      <point x="591" y="671" type="curve" smooth="yes"/>
+      <point x="653" y="671"/>
+      <point x="691" y="618"/>
+      <point x="691" y="566" type="curve" smooth="yes"/>
+      <point x="691" y="518"/>
+      <point x="663" y="451"/>
+      <point x="614" y="451" type="curve" smooth="yes"/>
+      <point x="586" y="451"/>
+      <point x="565" y="461"/>
+      <point x="558" y="466" type="curve"/>
+      <point x="551" y="457" type="line"/>
+      <point x="558" y="448"/>
+      <point x="581" y="432"/>
+      <point x="620" y="432" type="curve" smooth="yes"/>
+      <point x="687" y="432"/>
+      <point x="751" y="485"/>
+      <point x="751" y="564" type="curve" smooth="yes"/>
+      <point x="751" y="642"/>
+      <point x="696" y="686"/>
+      <point x="591" y="686" type="curve" smooth="yes"/>
+      <point x="443" y="686"/>
+      <point x="345" y="519"/>
+      <point x="345" y="334" type="curve" smooth="yes"/>
+      <point x="345" y="299" type="line"/>
+      <point x="236" y="299" type="line"/>
+      <point x="236" y="280" type="line"/>
+      <point x="344" y="280" type="line"/>
+      <point x="343" y="261"/>
+      <point x="342" y="245"/>
+      <point x="340" y="231" type="curve"/>
+      <point x="224" y="231" type="line"/>
     </contour>
     <contour>
-      <point x="181" y="120" type="curve" smooth="yes"/>
-      <point x="125" y="120"/>
-      <point x="87" y="105"/>
-      <point x="87" y="63" type="curve" smooth="yes"/>
-      <point x="87" y="27"/>
-      <point x="115" y="9"/>
-      <point x="157" y="9" type="curve" smooth="yes"/>
-      <point x="206" y="9"/>
-      <point x="249" y="40"/>
-      <point x="283" y="88" type="curve"/>
-      <point x="255" y="105"/>
       <point x="226" y="120"/>
+      <point x="255" y="105"/>
+      <point x="283" y="88" type="curve"/>
+      <point x="249" y="40"/>
+      <point x="206" y="9"/>
+      <point x="157" y="9" type="curve" smooth="yes"/>
+      <point x="115" y="9"/>
+      <point x="87" y="27"/>
+      <point x="87" y="63" type="curve" smooth="yes"/>
+      <point x="87" y="105"/>
+      <point x="125" y="120"/>
+      <point x="181" y="120" type="curve" smooth="yes"/>
     </contour>
   </outline>
   <lib>

--- a/OpenBaskerville.ufo/glyphs/t.glif
+++ b/OpenBaskerville.ufo/glyphs/t.glif
@@ -4,31 +4,31 @@
   <unicode hex="0074"/>
   <outline>
     <contour>
-      <point x="101" y="405" type="line"/>
-      <point x="41" y="405" type="line"/>
-      <point x="41" y="419" type="line"/>
-      <point x="126" y="431"/>
-      <point x="147" y="490"/>
-      <point x="158" y="549" type="curve"/>
-      <point x="168" y="549" type="line"/>
-      <point x="168" y="421" type="line"/>
-      <point x="285" y="421" type="line"/>
-      <point x="285" y="405" type="line"/>
-      <point x="168" y="405" type="line"/>
-      <point x="168" y="134" type="line" smooth="yes"/>
-      <point x="168" y="41"/>
-      <point x="181" y="7"/>
-      <point x="228" y="7" type="curve" smooth="yes"/>
-      <point x="276" y="7"/>
-      <point x="292" y="35"/>
-      <point x="299" y="47" type="curve"/>
-      <point x="307" y="42" type="line"/>
-      <point x="299" y="31"/>
-      <point x="289" y="-14"/>
-      <point x="197" y="-14" type="curve"/>
-      <point x="132" y="-14"/>
+      <point x="93" y="88" type="line" smooth="yes"/>
       <point x="91" y="17"/>
-      <point x="93" y="88" type="curve" smooth="yes"/>
+      <point x="132" y="-14"/>
+      <point x="197" y="-14" type="curve"/>
+      <point x="289" y="-14"/>
+      <point x="299" y="31"/>
+      <point x="307" y="42" type="curve"/>
+      <point x="299" y="47" type="line"/>
+      <point x="292" y="35"/>
+      <point x="276" y="7"/>
+      <point x="228" y="7" type="curve" smooth="yes"/>
+      <point x="181" y="7"/>
+      <point x="168" y="41"/>
+      <point x="168" y="134" type="curve" smooth="yes"/>
+      <point x="168" y="405" type="line"/>
+      <point x="285" y="405" type="line"/>
+      <point x="285" y="421" type="line"/>
+      <point x="168" y="421" type="line"/>
+      <point x="168" y="549" type="line"/>
+      <point x="158" y="549" type="line"/>
+      <point x="147" y="490"/>
+      <point x="126" y="431"/>
+      <point x="41" y="419" type="curve"/>
+      <point x="41" y="405" type="line"/>
+      <point x="101" y="405" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/three.glif
+++ b/OpenBaskerville.ufo/glyphs/three.glif
@@ -4,72 +4,72 @@
   <unicode hex="0033"/>
   <outline>
     <contour>
-      <point x="201" y="503" type="curve"/>
-      <point x="191" y="492"/>
-      <point x="174" y="492"/>
-      <point x="160" y="492" type="curve" smooth="yes"/>
-      <point x="106" y="492"/>
-      <point x="81" y="537"/>
-      <point x="81" y="570" type="curve" smooth="yes"/>
-      <point x="81" y="625"/>
-      <point x="138" y="689"/>
-      <point x="245" y="689" type="curve" smooth="yes"/>
-      <point x="395" y="689"/>
-      <point x="439" y="575"/>
-      <point x="439" y="520" type="curve" smooth="yes"/>
-      <point x="439" y="440"/>
-      <point x="387" y="382"/>
-      <point x="302" y="362" type="curve"/>
-      <point x="406" y="328"/>
-      <point x="453" y="269"/>
-      <point x="453" y="189" type="curve"/>
-      <point x="453" y="78"/>
-      <point x="375" y="-14"/>
-      <point x="218" y="-14" type="curve" smooth="yes"/>
-      <point x="178" y="-14"/>
-      <point x="25" y="-2"/>
-      <point x="25" y="126" type="curve" smooth="yes"/>
-      <point x="25" y="181"/>
-      <point x="64" y="225"/>
-      <point x="119" y="225" type="curve" smooth="yes"/>
-      <point x="125" y="225"/>
-      <point x="132" y="224"/>
-      <point x="139" y="223" type="curve"/>
-      <point x="108" y="202"/>
-      <point x="88" y="170"/>
-      <point x="88" y="126" type="curve" smooth="yes"/>
-      <point x="88" y="55"/>
-      <point x="128" y="2"/>
-      <point x="218" y="2" type="curve" smooth="yes"/>
-      <point x="318" y="2"/>
-      <point x="376" y="81"/>
-      <point x="376" y="182" type="curve" smooth="yes"/>
-      <point x="376" y="283"/>
-      <point x="318" y="345"/>
-      <point x="270" y="345" type="curve" smooth="yes"/>
-      <point x="232" y="345"/>
-      <point x="221" y="310"/>
-      <point x="189" y="310" type="curve" smooth="yes"/>
-      <point x="174" y="310"/>
-      <point x="151" y="319"/>
-      <point x="151" y="344" type="curve" smooth="yes"/>
-      <point x="151" y="366"/>
-      <point x="167" y="379"/>
-      <point x="193" y="379" type="curve" smooth="yes"/>
-      <point x="222" y="379"/>
-      <point x="224" y="365"/>
-      <point x="253" y="365" type="curve" smooth="yes"/>
-      <point x="266" y="365"/>
-      <point x="362" y="378"/>
-      <point x="362" y="520" type="curve" smooth="yes"/>
-      <point x="362" y="610"/>
-      <point x="331" y="674"/>
-      <point x="235" y="674" type="curve" smooth="yes"/>
-      <point x="155" y="674"/>
-      <point x="137" y="616"/>
-      <point x="137" y="588" type="curve" smooth="yes"/>
-      <point x="137" y="544"/>
       <point x="161" y="514"/>
+      <point x="137" y="544"/>
+      <point x="137" y="588" type="curve" smooth="yes"/>
+      <point x="137" y="616"/>
+      <point x="155" y="674"/>
+      <point x="235" y="674" type="curve" smooth="yes"/>
+      <point x="331" y="674"/>
+      <point x="362" y="610"/>
+      <point x="362" y="520" type="curve" smooth="yes"/>
+      <point x="362" y="378"/>
+      <point x="266" y="365"/>
+      <point x="253" y="365" type="curve" smooth="yes"/>
+      <point x="224" y="365"/>
+      <point x="222" y="379"/>
+      <point x="193" y="379" type="curve" smooth="yes"/>
+      <point x="167" y="379"/>
+      <point x="151" y="366"/>
+      <point x="151" y="344" type="curve" smooth="yes"/>
+      <point x="151" y="319"/>
+      <point x="174" y="310"/>
+      <point x="189" y="310" type="curve" smooth="yes"/>
+      <point x="221" y="310"/>
+      <point x="232" y="345"/>
+      <point x="270" y="345" type="curve" smooth="yes"/>
+      <point x="318" y="345"/>
+      <point x="376" y="283"/>
+      <point x="376" y="182" type="curve" smooth="yes"/>
+      <point x="376" y="81"/>
+      <point x="318" y="2"/>
+      <point x="218" y="2" type="curve" smooth="yes"/>
+      <point x="128" y="2"/>
+      <point x="88" y="55"/>
+      <point x="88" y="126" type="curve" smooth="yes"/>
+      <point x="88" y="170"/>
+      <point x="108" y="202"/>
+      <point x="139" y="223" type="curve"/>
+      <point x="132" y="224"/>
+      <point x="125" y="225"/>
+      <point x="119" y="225" type="curve" smooth="yes"/>
+      <point x="64" y="225"/>
+      <point x="25" y="181"/>
+      <point x="25" y="126" type="curve" smooth="yes"/>
+      <point x="25" y="-2"/>
+      <point x="178" y="-14"/>
+      <point x="218" y="-14" type="curve" smooth="yes"/>
+      <point x="375" y="-14"/>
+      <point x="453" y="78"/>
+      <point x="453" y="189" type="curve"/>
+      <point x="453" y="269"/>
+      <point x="406" y="328"/>
+      <point x="302" y="362" type="curve"/>
+      <point x="387" y="382"/>
+      <point x="439" y="440"/>
+      <point x="439" y="520" type="curve" smooth="yes"/>
+      <point x="439" y="575"/>
+      <point x="395" y="689"/>
+      <point x="245" y="689" type="curve" smooth="yes"/>
+      <point x="138" y="689"/>
+      <point x="81" y="625"/>
+      <point x="81" y="570" type="curve" smooth="yes"/>
+      <point x="81" y="537"/>
+      <point x="106" y="492"/>
+      <point x="160" y="492" type="curve" smooth="yes"/>
+      <point x="174" y="492"/>
+      <point x="191" y="492"/>
+      <point x="201" y="503" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/OpenBaskerville.ufo/glyphs/tilde.glif
+++ b/OpenBaskerville.ufo/glyphs/tilde.glif
@@ -4,26 +4,26 @@
   <unicode hex="02DC"/>
   <outline>
     <contour>
-      <point x="316" y="642" type="line"/>
-      <point x="316" y="600"/>
-      <point x="278" y="557"/>
-      <point x="232" y="557" type="curve" smooth="yes"/>
-      <point x="174" y="557"/>
-      <point x="139" y="597"/>
-      <point x="85" y="597" type="curve" smooth="yes"/>
-      <point x="50" y="597"/>
-      <point x="38" y="562"/>
-      <point x="38" y="562" type="curve"/>
-      <point x="18" y="562" type="line"/>
-      <point x="18" y="615"/>
-      <point x="66" y="646"/>
-      <point x="100" y="646" type="curve" smooth="yes"/>
-      <point x="155" y="646"/>
-      <point x="199" y="607"/>
-      <point x="239" y="607" type="curve" smooth="yes"/>
-      <point x="284" y="607"/>
+      <point x="301" y="644" type="line"/>
       <point x="301" y="626"/>
-      <point x="301" y="644" type="curve"/>
+      <point x="284" y="607"/>
+      <point x="239" y="607" type="curve" smooth="yes"/>
+      <point x="199" y="607"/>
+      <point x="155" y="646"/>
+      <point x="100" y="646" type="curve" smooth="yes"/>
+      <point x="66" y="646"/>
+      <point x="18" y="615"/>
+      <point x="18" y="562" type="curve"/>
+      <point x="38" y="562" type="line"/>
+      <point x="38" y="562"/>
+      <point x="50" y="597"/>
+      <point x="85" y="597" type="curve" smooth="yes"/>
+      <point x="139" y="597"/>
+      <point x="174" y="557"/>
+      <point x="232" y="557" type="curve" smooth="yes"/>
+      <point x="278" y="557"/>
+      <point x="316" y="600"/>
+      <point x="316" y="642" type="curve"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
Having both PostScript and TrueType contour directions between glyphs alone is no issue these days, but it bites back with unfilled overlaps in composites. In fact, sketching with those is exactly how I spotted it. I didn't touch the recent Century Catalogue part, though, as this will be reworked anyway.
